### PR TITLE
Don't enforce web as procfile entry

### DIFF
--- a/deploy/base/pipeline.yaml
+++ b/deploy/base/pipeline.yaml
@@ -45,7 +45,7 @@ spec:
       default: []
     - name: PROCESS_TYPE
       description: The default process type to set on the image.
-      default: "web"
+      default: ""
       type: "string"
     - name: RUN_IMAGE
       description: The name of the run image to use (defaults to image specified in builder).

--- a/deploy/base/task-combined.yaml
+++ b/deploy/base/task-combined.yaml
@@ -159,7 +159,7 @@ spec:
       default: []
     - name: PROCESS_TYPE
       description: The default process type to set on the image.
-      default: "web"
+      default: ""
     - name: RUN_IMAGE
       description: Reference to a run image to use.
       default: ""


### PR DESCRIPTION
This allows using any other name, and will use the first one it find as the default command.

We might want to change the way we start bulidservice images too to pick the web procfile entry, or not :)

Bug: T336050